### PR TITLE
New command timeout option

### DIFF
--- a/DataFace.Test/MySqlIntegrationTests/MySqlTests.cs
+++ b/DataFace.Test/MySqlIntegrationTests/MySqlTests.cs
@@ -125,7 +125,7 @@ namespace DataFace.Test.MySqlIntegrationTests {
             using (var transaction = connection.BeginTransaction()) {
                 foreach (var batch in ReadSqlFileIntoBatches("MySqlIntegrationTests\\CreateTestDatabase.sql")) {
                     if (batch.Trim() != "") {
-                        transaction.ExecuteAdHocQuery(batch);
+                        transaction.ExecuteAdHocQuery(batch, new CommandOptions { CommandTimeout = 30 });
                     }
                 }
 

--- a/DataFace.Test/PostgreSqlIntegrationTests/PostgreSqlTests.cs
+++ b/DataFace.Test/PostgreSqlIntegrationTests/PostgreSqlTests.cs
@@ -118,7 +118,7 @@ namespace DataFace.Test.PostgreSqlIntegrationTests {
             using (var transaction = connection.BeginTransaction()) {
                 foreach (var batch in ReadSqlFileIntoBatches("PostgreSqlIntegrationTests\\CreateTestDatabase.sql")) {
                     if (batch.Trim() != "") {
-                        transaction.ExecuteAdHocQuery(batch);
+                        transaction.ExecuteAdHocQuery(batch, new CommandOptions { CommandTimeout = 30 });
                     }
                 }
 

--- a/DataFace.Test/SqlServerIntegrationTests/SqlServerTests.cs
+++ b/DataFace.Test/SqlServerIntegrationTests/SqlServerTests.cs
@@ -121,7 +121,7 @@ namespace DataFace.Test.SqlServerIntegrationTests {
             using (var transaction = connection.BeginTransaction()) {
                 foreach (var batch in ReadSqlFileIntoBatches("SqlServerIntegrationTests\\CreateTestDatabase.sql")) {
                     if (batch.Trim() != "") {
-                        transaction.ExecuteAdHocQuery(batch);
+                        transaction.ExecuteAdHocQuery(batch, new CommandOptions { CommandTimeout = 30 });
                     }
                 }
 

--- a/DataFace/Core/CommandOptions.cs
+++ b/DataFace/Core/CommandOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataFace.Core {
+    public class CommandOptions {
+        public int CommandTimeout { get; set; }
+    }
+}

--- a/DataFace/Core/ITransaction.cs
+++ b/DataFace/Core/ITransaction.cs
@@ -5,8 +5,8 @@ using System.Text;
 
 namespace DataFace.Core {
     public interface ITransaction : IDisposable {
-        List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters);
-        List<ResultSet> ExecuteAdHocQuery(string adhocQuery);
+        List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters, CommandOptions commandOptions);
+        List<ResultSet> ExecuteAdHocQuery(string adhocQuery, CommandOptions commandOptions);
         void Commit();
         void Rollback();
     }

--- a/DataFace/DataFace.csproj
+++ b/DataFace/DataFace.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Core\BaseRepository.cs" />
     <Compile Include="Core\Column.cs" />
     <Compile Include="Core\DataFaceException.cs" />
+    <Compile Include="Core\CommandOptions.cs" />
     <Compile Include="Core\IDatabaseConnection.cs" />
     <Compile Include="Core\IEnumerableExtensions.cs" />
     <Compile Include="Core\ITransaction.cs" />

--- a/DataFace/MySql/MySqlTransaction.cs
+++ b/DataFace/MySql/MySqlTransaction.cs
@@ -14,18 +14,21 @@ namespace DataFace.MySql {
         private RawConnection connection;
         private RawTransaction transaction;
 
+        public int CommandTimeout { get; set; }
+
         public MySqlTransaction(MySqlDatabaseConnection databaseConnection) {
             this.connection = new RawConnection(databaseConnection.ConnectionString);
             this.connection.Open();
             this.transaction = this.connection.BeginTransaction();
         }
 
-        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters) {
+        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters, CommandOptions commandOptions) {
             if (procedureName.Contains('.')) {
                 throw new ArgumentException("MySql does not support schemas");
             }
 
             using (var command = new MySqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.StoredProcedure;
                 command.CommandText = procedureName;
                 command.Connection = connection;
@@ -41,8 +44,9 @@ namespace DataFace.MySql {
             }
         }
 
-        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery) {
+        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery, CommandOptions commandOptions) {
             using (var command = new MySqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.Text;
                 command.CommandText = adhocQuery;
                 command.Connection = connection;

--- a/DataFace/Postgres/PostgreSqlTransaction.cs
+++ b/DataFace/Postgres/PostgreSqlTransaction.cs
@@ -11,14 +11,17 @@ namespace DataFace.PostgreSql {
         private NpgsqlConnection connection;
         private NpgsqlTransaction transaction;
 
+        public int CommandTimeout { get; set; }
+
         public PostgreSqlTransaction(PostgreSqlDatabaseConnection databaseConnection) {
             this.connection = new NpgsqlConnection(databaseConnection.ConnectionString);
             this.connection.Open();
             this.transaction = this.connection.BeginTransaction();
         }
 
-        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters) {
+        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters, CommandOptions commandOptions) {
             using (var command = new NpgsqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.StoredProcedure;
                 command.CommandText = procedureName;
                 command.Connection = connection;
@@ -34,8 +37,9 @@ namespace DataFace.PostgreSql {
             }
         }
 
-        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery) {
+        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery, CommandOptions commandOptions) {
             using (var command = new NpgsqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.Text;
                 command.CommandText = adhocQuery;
                 command.Connection = connection;

--- a/DataFace/SqlServer/SqlServerTransaction.cs
+++ b/DataFace/SqlServer/SqlServerTransaction.cs
@@ -11,13 +11,16 @@ namespace DataFace.SqlServer {
         private SqlConnection connection;
         private SqlTransaction transaction;
 
+        public int CommandTimeout { get; set; }
+
         public SqlServerTransaction(SqlServerDatabaseConnection databaseConnection) {
             this.connection = new SqlConnection(databaseConnection.ConnectionString);
         }
 
-        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters) {
+        public List<ResultSet> ExecuteStoredProcedure(string procedureName, Dictionary<string, object> parameters, CommandOptions commandOptions) {
             Open();
             using (var command = new SqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.StoredProcedure;
                 command.CommandText = procedureName;
                 command.Connection = connection;
@@ -33,9 +36,10 @@ namespace DataFace.SqlServer {
             }
         }
 
-        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery) {
+        public List<ResultSet> ExecuteAdHocQuery(string adhocQuery, CommandOptions commandOptions) {
             Open();
             using (var command = new SqlCommand()) {
+                command.CommandTimeout = commandOptions.CommandTimeout;
                 command.CommandType = CommandType.Text;
                 command.CommandText = adhocQuery;
                 command.Connection = connection;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# DataFace: Easy Database Interfacing for C# 
+# DataFace: Easy Database Interfacing for C#
 
 DataFace helps your C# project have a clear and easy to manage database access layer.
 
@@ -14,15 +14,15 @@ using DataFace.SqlServer;
 public class MyRepository : BaseRepository {
 	public MyRepository() : base(new SqlServerDatabaseConnection("myConnectionString")) {
     }
-    
+
     public int ScalarExample(int sprocParameter) {
         return ExecuteStoredProcedure(new object[] { sprocParameter }).ToScalar<int>();
     }
-	   
+
     public List<RowModel> RowsExample() {
         return ExecuteStoredProcedure(new object[] {}).ToRows<RowModel>();
     }
-    
+
     public MultipleResultSetModel MultipleResultSetExample() {
         return ExecuteStoredProcedure(new object[] {}).ToMultipleResultSetModel<MultipleResultSetModel>();
     }
@@ -49,15 +49,15 @@ This is accomplished through reflection. DataFace reflects on the input model ty
 public class MyRepository : BaseRepository {
 	public MyRepository() : base(new SqlServerDatabaseConnection("myConnectionString")) {
     }
-    
+
     public int ScalarExample(InputModel input) {
         return ExecuteStoredProcedure<InputModel>(input).ToScalar<int>();
     }
-	   
+
     public List<RowModel> RowsExample(InputModel input) {
         return ExecuteStoredProcedure<InputModel>(input).ToRows<RowModel>();
     }
-    
+
     public MultipleResultSetModel MultipleResultSetExample(InputModel input) {
         return ExecuteStoredProcedure<InputModel>(input).ToMultipleResultSetModel<MultipleResultSetModel>();
     }
@@ -76,6 +76,26 @@ public class InputModel {
 
 ```
 
+### Optional Command Options
+
+Optional command options can be supplied to set CommandTimeout for both adhoc queries and stored procedures.
+
+```
+
+// Standard call to ExecuteStoredProcedure without command options.
+[Schema("purge")]
+public void DeletePurgeJob(int jobId) {
+    ExecuteStoredProcedure(new GeneralUse.JobID(jobId));
+}
+
+// The same call including a 60 second command timeout.
+[Schema("purge")]
+public void DeletePurgeJob(int jobId) {
+    ExecuteStoredProcedure(new GeneralUse.JobID(jobId), new CommandOptions { CommandTimeout = 60 });
+}
+
+```
+
 ### Usage
 
 * Install DataFace as a [nuget package](https://www.nuget.org/packages/DataFace/) onto your solution
@@ -83,4 +103,3 @@ public class InputModel {
 * In the constructor, choose which IDatabaseConnection to use (only SQL Server is supported for now)
 * Fill out your model with stored procedures as methods of the repository.  Use ToRows, ToSingleRow, and other helper methods to process your database results.
 * Write code that uses your new database access layer!
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ public class MyRepository : BaseRepository {
     public int ScalarExample(int sprocParameter) {
         return ExecuteStoredProcedure(new object[] { sprocParameter }).ToScalar<int>();
     }
-    
+	   
     public List<RowModel> RowsExample() {
         return ExecuteStoredProcedure(new object[] {}).ToRows<RowModel>();
     }
@@ -36,9 +36,45 @@ public class MultipleResultSetModel {
 	[ResultSet(0, ResultSetType.Rows)]
 	public List<RowModel> ExampleResultSet { get; set; }
 }
+
+```
+In the above example, ```ScalarExample```, ```RowsExample```, and ```MultipleResultSetExample``` are stored procedures in a SQL Server database.  DataFace uses reflection to find the name of the stored procedures and parameters declared in your repository class.  It then provides helper methods for processing the results to scalar, a single row, many rows, or even multiple result sets.
+
+Often, a stored procedure will contain a number of input parameters, such as in the ```InputModel``` class below.
+While DataFace supports the ability to explicitly list each parameter in the object array input for the ```ExecuteStoredProcedure``` method, it is typically more efficient to use generics, and let DataFace process the input models on your behalf.
+This is accomplished through reflection. DataFace reflects on the input model type, and produces a parameter for each property within the model.
+
 ```
 
-In the above example, ```ScalarExample```, ```RowsExample```, and ```MultipleResultSetExample``` are stored procedures in a SQL Server database.  DataFace uses reflection to find the name of the stored procedures and parameters declared in your repository class.  It then provides helper methods for processing the results to scalar, a single row, many rows, or even multiple result sets.
+public class MyRepository : BaseRepository {
+	public MyRepository() : base(new SqlServerDatabaseConnection("myConnectionString")) {
+    }
+    
+    public int ScalarExample(InputModel input) {
+        return ExecuteStoredProcedure<InputModel>(input).ToScalar<int>();
+    }
+	   
+    public List<RowModel> RowsExample(InputModel input) {
+        return ExecuteStoredProcedure<InputModel>(input).ToRows<RowModel>();
+    }
+    
+    public MultipleResultSetModel MultipleResultSetExample(InputModel input) {
+        return ExecuteStoredProcedure<InputModel>(input).ToMultipleResultSetModel<MultipleResultSetModel>();
+    }
+}
+
+public class InputModel {
+	public int Item1 {get; set;}
+	public int Item2 {get; set;}
+	public int Item3 {get; set;}
+	public int Item4 {get; set;}
+	public int Item5 {get; set;}
+	public int Item6 {get; set;}
+	public int Item7 {get; set;}
+	public int Item8 {get; set;}
+}
+
+```
 
 ### Usage
 


### PR DESCRIPTION
I threw this solution together on the bus ride home.

I think I found a good seam for shimming a general CommandOptions override behavior. I tried to construct the change in a way that is reasonable to manage, backwards compatible, and lends towards future growth opportunites... but who knows, maybe I'm just smoking crack.

You'll notice that in BaseRepositoy the ExecuteStoredProcedure method is starting to get a bit overloaded (4 overloads). This isn't necessarily a problem, but I would venture to say that some of the overloads could be marked as deprecated at some point in the future (those that support ```Object[] {}``` style input parameter instances).

I also had to make some minor changes to a few of the integration tests since they directly instantiate TransactionContexts. However, I _think_ this is probably an acceptable change.